### PR TITLE
Change to use RAT maven plugin to support ASF short format header

### DIFF
--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -23,6 +23,7 @@ if [ $sysOS == "Darwin" ];then
 	echo "This is MacOS."
 	brew install jq
 	brew install gpg
+	brew install maven
 elif [ $sysOS == "Linux" ];then
 	echo "This is Linux."
     if [ -f /etc/lsb-release -o -d /etc/lsb-release.d ]; then
@@ -32,7 +33,7 @@ elif [ $sysOS == "Linux" ];then
     fi
     if [ $DISTRO == "Ubuntu" ];then
         echo "This is Ubuntu."
-        sudo apt-get install jq gnupg expect
+        sudo apt-get install jq gnupg expect maven
     fi
 else
 	echo "Other OS: $sysOS. Please manually install jq library."

--- a/tools/lib/pom.xml
+++ b/tools/lib/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.incubator.openwhisk.release</groupId>
+  <artifactId>header-check</artifactId>
+  <version>1.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>0.12</version>
+        <configuration>
+          <licenses>
+            <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+              <licenseFamilyCategory>ALSF</licenseFamilyCategory>
+              <licenseFamilyName>Apache License 2.0 Short Form</licenseFamilyName>
+              <notes></notes>
+              <patterns>
+                <pattern>Licensed to the Apache Software Foundation (ASF) under one or more contributor</pattern>
+              </patterns>
+            </license>
+          </licenses>
+          <licenseFamilies>
+            <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
+              <familyName>Apache License 2.0 Short Form</familyName>
+            </licenseFamily>
+          </licenseFamilies>
+          <excludes>
+            <!-- JSON files -->
+            <exclude>**/*.json</exclude>
+            <!-- gradle files -->
+            <exclude>**/**.gradle</exclude>
+            <exclude>**/gradlew**</exclude>
+            <exclude>**/gradle/**</exclude>
+            <!-- configuration files with dot as the prefix -->
+            <exclude>**/.**</exclude>
+            <!-- template files -->
+            <exclude>**/templates/**</exclude>
+            <!-- <exclude>**/*.j2.ini</exclude> -->
+            <exclude>**/*.j2.*</exclude>
+            <exclude>**/.github/**</exclude>
+            <!-- OpenWhisk auth data -->
+            <exclude>**/auth.whisk.system</exclude>
+            <exclude>**/auth.guest</exclude>
+            <!-- i18n file auto generated -->
+            <exclude>**/i18n_resources.go</exclude>
+            <!-- NOTICE files -->
+            <exclude>**/NOTICE.md</exclude>
+            <!-- Test data / src files -->
+            <!-- <exclude>*/tests/dat/**</exclude> -->
+            <!-- <exclude>*/tests/src/**</exclude> -->
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/verify_source_code.sh
+++ b/tools/verify_source_code.sh
@@ -24,13 +24,10 @@ SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 source "$SCRIPTDIR/load_config.sh" $1
 PARENTDIR="$(dirname "$SCRIPTDIR")"
 
-REPORT_DIR=$PARENTDIR/report
-REPORT_FILE=$REPORT_DIR/apache-rat-report.txt
-
-mkdir -p $REPORT_DIR
-touch $REPORT_FILE
-
-java -jar $SCRIPTDIR/lib/apache-rat-0.13-SNAPSHOT.jar -a $OPENWHISK_CLEANED_SOURCE_DIR > $REPORT_FILE
+# run Apache rat to check headers
+cd $OPENWHISK_SOURCE_DIR
+cp $SCRIPTDIR/lib/pom.xml ./
+mvn clean apache-rat:check
 
 echo "Check the existence of LICENSE and NOTICE."
 
@@ -38,5 +35,5 @@ for repo in $(echo $repos | sed "s/,/ /g")
 do
     repo_name=$(echo "$repo" | sed -e 's/^"//' -e 's/"$//')
     echo "Check the repository $repo_name"
-    cd $OPENWHISK_CLEANED_SOURCE_DIR/$repo_name && ls {LICENSE*,NOTICE*}
+    cd $OPENWHISK_SOURCE_DIR/$repo_name && ls {LICENSE*,NOTICE*}
 done


### PR DESCRIPTION
This pr is to use RAT maven plugin to support ASF short format header, including:
- pom.xml used by maven, including a customer license definition and a list of "exclude" files.
- add script to install maven
- change verify_source_code.sh to use apache rat maven plugin