### PR TITLE
Change the directory to generate the release notes

### DIFF
--- a/docs/generate_release_notes.md
+++ b/docs/generate_release_notes.md
@@ -1,0 +1,27 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.  The ASF licenses this file to you
+# under the Apache License, Version 2.0 (the # "License"); you may not use this
+# file except in compliance with the License.  You may obtain a copy of the License
+# at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+-->
+
+# Generate the release notes
+
+Make sure that the source code is downloaded via the script download_source_code.sh. The release notes can be generated
+by running the following script under the directory _tools_:
+```
+$ ./generate_release_notes.sh <WORK_DIR>
+```
+The parameter <WORK_DIR> should be the same one used to download the source code. This script will generate a release
+notes file named releaseNotes.md under the directory <WORK_DIR>/openwhisk_release/openwhisk_sources.

--- a/docs/package_artifacts.md
+++ b/docs/package_artifacts.md
@@ -16,7 +16,22 @@
 #
 -->
 
-# Making the release artifacts
+# Package the artifacts
+
+## Verify the source code
+
+Before generating any release artifacts, it is recommended to verify the source code by checking the license headers and
+the existence of LICENSE and NOTICE files under each repository. This step can be done by running the following script
+under the directory _tools_:
+```
+$ ./verify_source_code.sh <WORK_DIR>
+```
+The <WORK_DIR> should be the same one used to download the source code. This script will generate a RAT report called
+rat.txt under the directory <WORK_DIR>/openwhisk_release/openwhisk_sources/target. You can find the status of license
+header in this RAT report. In addition, you can check the existence of LICENSE and NOTICE from the terminal, after
+running this script.
+
+## Making the release artifacts
 
 The artifacts to be made in this step consists of the source code packages, binary packages and docker image packages.
 As the deliverable of the [first phase](general_spec.md#different-phases-of-implementations), we currently only build the

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -36,7 +36,8 @@ the artifacts in the staging directory and the Apache release directory.
   8. Vote on the dev@openwhisk.apache.org list
   9. If the vote fails - configure the file config.json and resume from step 3
   10. [Publish the release artifacts to Apache release directory](publish_apache_directory.md)
-  11. Announce the release
+  11. [Generate the release notes](generate_release_notes.md)
+  12. Announce the release
 
 ## Automated mode of Release Process
 

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -24,7 +24,7 @@ SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 source "$SCRIPTDIR/load_config.sh" $1
 PARENTDIR="$(dirname "$SCRIPTDIR")"
 
-FILE="$WORK_DIR/releaseNotes.md"
+FILE="$OPENWHISK_SOURCE_DIR/releaseNotes.md"
 TEMPLATE="$SCRIPTDIR/lib/release_template.md"
 
 # Remove file if exists


### PR DESCRIPTION
By default, the release notes file is saved under the $HOME or the WORK_DIR. This
PR changes the directory to $OPENWHISK_SOURCE_DIR for convenient management.

In addition, add the documentation to describe how to generate the release notes and
how to verify the source code.