### PR TITLE
Add the config option to determine whether to push the artifacts or not

### DIFF
--- a/tools/config.json
+++ b/tools/config.json
@@ -1,4 +1,5 @@
 {
+  "publish_stage": "false",
   "stage_url": "https://dist.apache.org/repos/dist/dev/incubator/openwhisk",
   "release_url": "https://dist.apache.org/repos/dist/release/incubator/openwhisk",
   "version": {

--- a/tools/load_config.sh
+++ b/tools/load_config.sh
@@ -17,10 +17,10 @@
 #
 
 WORK_DIR=${1:-"$HOME"}
-SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-
+DIR="$(cd $(dirname "$0")/ && pwd)"
 SVN_USERNAME=$2
 SVN_PASSWORD=$3
+SCRIPTDIR=${4:-"$DIR"}
 CREDENTIALS=""
 
 if [ ! -z "$SVN_USERNAME" ] && [ ! -z "$SVN_PASSWORD" ];then
@@ -35,6 +35,7 @@ OPENWHISK_SVN="$OPENWHISK_RELEASE_DIR/openwhisk"
 source "$SCRIPTDIR/util.sh"
 
 CONFIG=$(read_file $SCRIPTDIR/config.json)
+PUBLISH_STAGE=$(json_by_key "$CONFIG" "publish_stage")
 repos=$(echo $(json_by_key "$CONFIG" "RepoList") | sed 's/[][]//g')
 STAGE_URL=$(json_by_key "$CONFIG" "stage_url")
 

--- a/tools/travis/package_source_code.sh
+++ b/tools/travis/package_source_code.sh
@@ -27,16 +27,19 @@ PARENTDIR="$(dirname "$SCRIPTDIR")"
 SVN_USERNAME=$2
 SVN_PASSWORD=$3
 
+source "$PARENTDIR/load_config.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD" "$PARENTDIR"
+
 "$PARENTDIR/install_dependencies.sh"
-"$PARENTDIR/download_source_code.sh" $WORK_DIR
-"$PARENTDIR/checkout_svn.sh" $WORK_DIR $SVN_USERNAME $SVN_PASSWORD
+"$PARENTDIR/download_source_code.sh" "$WORK_DIR"
+"$PARENTDIR/checkout_svn.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
 
-"$PARENTDIR/package_source_code.sh" $WORK_DIR $SVN_USERNAME $SVN_PASSWORD
 
-if [ "$TRAVIS_EVENT_TYPE" == "push" ] ; then
+"$PARENTDIR/package_source_code.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+
+if [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ "$PUBLISH_STAGE" == "true" ] ; then
     "$SCRIPTDIR/import_pgp_key.sh"
-    "$PARENTDIR/sign_artifacts.sh" $WORK_DIR
-    "$PARENTDIR/upload_artifacts.sh" $WORK_DIR $SVN_USERNAME $SVN_PASSWORD
+    "$PARENTDIR/sign_artifacts.sh" "$WORK_DIR"
+    "$PARENTDIR/upload_artifacts.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
 fi
 
-"$PARENTDIR/verify_source_code.sh" $WORK_DIR
+"$PARENTDIR/verify_source_code.sh" "$WORK_DIR"


### PR DESCRIPTION
This PR adds a config option "publish_stage" in the configuration file
to determine whether this commit will push new artifacts into the
staging URL or not. By default, it is set to false, meaning it will
not push new artifacts. We can set it to true in order to push new
artifacts.