### PR TITLE
Add openwhisk-kube-deploy to list of release repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ The following table can be used by Release Managers to get quickly check the sta
 <td><a href="https://github.com/apache/incubator-openwhisk-wskdeploy/blob/master/tools/travis/scancode.sh">scancode.sh</a></td>
 </tr>
 <tr align="left">
+<td><a href="https://github.com/apache/incubator-openwhisk-deploy-kube">incubator-openwhisk-deploy-kube</a></td>
+<td><a href="https://travis-ci.org/apache/incubator-openwhisk-deploy-kube/branches"><img src="https://travis-ci.org/apache/incubator-openwhisk-deploy-kube.svg?branch=master" alt="" /></a></td>
+<td><a href="https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/LICENSE.txt"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="" /></a></td>
+<td><a href="https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/NOTICE.txt">NOTICE</a></td>
+<td><a href="https://openwhisk-team.slack.com/messages/C4J3R7JFL/"><img src="https://img.shields.io/badge/channel-Slack-800080.svg" alt="" /></a></td>
+<td><a href="https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/tools/travis/scancode.sh">scancode.sh</a></td>
+</tr>
+<tr align="left">
 <td><a href="https://github.com/apache/incubator-openwhisk-runtime-nodejs">incubator-openwhisk-runtime-nodejs</a></td>
 <td><a href="https://travis-ci.org/apache/incubator-openwhisk-runtime-nodejs/branches"><img src="https://travis-ci.org/apache/incubator-openwhisk-runtime-nodejs.svg?branch=master" alt="" /></a></td>
 <td><a href="https://github.com/apache/incubator-openwhisk-runtime-nodejs/blob/master/LICENSE.txt"><img src="https://camo.githubusercontent.com/3a4d3bc039085cffdfecbe3077ffe49c5fe23286/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4170616368652d2d322e302d626c75652e737667" alt="" /></a></td>

--- a/docs/general_spec.md
+++ b/docs/general_spec.md
@@ -63,6 +63,8 @@ We plan to release the following OpenWhisk repositories:
     - [incubator-openwhisk-runtime-docker](https://github.com/apache/incubator-openwhisk-runtime-docker)
 - OpenWhisk catalog: [incubator-openwhisk-catalog](https://github.com/apache/incubator-openwhisk-catalog)
 - OpenWhisk API gateway: [incubator-openwhisk-apigateway](https://github.com/apache/incubator-openwhisk-apigateway)
+- OpenWhisk deployment support:
+    - [incubator-openwhisk-deploy-kube](https://github.com/apache/incubator-openwhisk-deploy-kube)
 - OpenWhisk clients:
     - [incubator-openwhisk-client-go](https://github.com/apache/incubator-openwhisk-client-go)
     - [incubator-openwhisk-cli](https://github.com/apache/incubator-openwhisk-cli)

--- a/tools/config.json
+++ b/tools/config.json
@@ -12,6 +12,7 @@
     "openwhisk-cli",
     "openwhisk-client-go",
     "openwhisk-catalog",
+    "openwhisk-deploy-kube",
     "openwhisk-apigateway",
     "openwhisk-runtime-nodejs",
     "openwhisk-runtime-swift",
@@ -45,6 +46,11 @@
   "openwhisk_catalog": {
     "hash": "7f47212",
     "repository": "https://github.com/apache/incubator-openwhisk-catalog.git",
+    "branch": "master"
+  },
+  "openwhisk_deploy_kube": {
+    "hash": "7340cc9",
+    "repository": "https://github.com/apache/incubator-openwhisk-deploy-kube.git",
     "branch": "master"
   },
   "openwhisk_apigateway": {


### PR DESCRIPTION
I believe the openwhisk-kube-deploy is compliant with all the requirements to be included as part of a release.  I think it would be useful to include this repo in the release set so that the Helm chart for Kubernetes deployment would be properly versioned and included in each OpenWhisk release.

