### PR TITLE
Remove the WORK_DIR to simplify the configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
     #- stage: deploy
     #  script: ./tools/travis/setup.sh
     - stage: package
-      script: ./tools/travis/package_project.sh $(dirname "$TRAVIS_BUILD_DIR") $SVN_USERNAME $SVN_PASSWORD
+      script: ./tools/travis/package_project.sh $SVN_USERNAME $SVN_PASSWORD
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then

--- a/docs/generate_release_notes.md
+++ b/docs/generate_release_notes.md
@@ -22,7 +22,6 @@
 Make sure that the source code is downloaded via the script download_source_code.sh. The release notes can be generated
 by running the following script under the directory _tools_:
 ```
-$ ./generate_release_notes.sh <WORK_DIR>
+$ ./generate_release_notes.sh
 ```
-The parameter <WORK_DIR> should be the same one used to download the source code. This script will generate a release
-notes file named releaseNotes.md under the directory <WORK_DIR>/openwhisk_release/openwhisk_sources.
+This script will generate a release notes file named releaseNotes.md under the directory <local_release_dir>/openwhisk_release/openwhisk_sources.

--- a/docs/license_compliance.md
+++ b/docs/license_compliance.md
@@ -160,7 +160,7 @@ done
 
 After downloading the source codes to your local disk, run the following script to verify license compliance:
 ```
-$ ./tools/travis/verify_source_code.sh <WORK_DIR>
+$ ./tools/travis/verify_source_code.sh
 ```
 
 ### Apache Tentacles

--- a/docs/package_artifacts.md
+++ b/docs/package_artifacts.md
@@ -25,10 +25,9 @@ Before generating any release artifacts, it is recommended to verify the source 
 the existence of LICENSE and NOTICE files under each repository. This step can be done by running the following script
 under the directory _tools_:
 ```
-$ ./verify_source_code.sh <WORK_DIR>
+$ ./verify_source_code.sh
 ```
-The <WORK_DIR> should be the same one used to download the source code. This script will generate a RAT report called
-rat.txt under the directory <WORK_DIR>/openwhisk_release/openwhisk_sources/target. You can find the status of license
+This script will generate a RAT report called rat.txt under the directory <local_release_dir>/openwhisk_release/openwhisk_sources/target. You can find the status of license
 header in this RAT report. In addition, you can check the existence of LICENSE and NOTICE from the terminal, after
 running this script.
 
@@ -40,8 +39,7 @@ source code packages. Binary and docker image are on our future agenda.
 
 After downloading the source code, we can run the following script under _tools_ to generate the artifacts for each OpenWhisk project:
 ```
-$ ./package_source_code.sh <WORK_DIR>
+$ ./package_source_code.sh
 ```
-The <WORK_DIR> should be the same one used to download the source code. This script will create a source code package file
-of source code suffixed with tar.gz for each project, under <WORK_DIR>/openwhisk_sources/openwhisk/openwhisk-\<version\>.
+This script will create a source code package file of source code suffixed with tar.gz for each project, under <local_release_dir>/openwhisk_sources/openwhisk/openwhisk-\<version\>.
 The key version is defined in _config.json_.

--- a/docs/pick_up_source_code.md
+++ b/docs/pick_up_source_code.md
@@ -75,22 +75,27 @@ Template of [_config.json_](../tools/config.json):
 ## Download the source code to a local directory
 
 Run the following script to download source code based on the configuration in _config.json_:
+
 ```
-$ ./download_source_code.sh <WORK_DIR>
+$ ./download_source_code.sh
 ```
-You may specify where to download all the source code with <WORK_DIR>. If you specify the <WORK_DIR> here, you need to
-specify the same value as well to the sequential scripts as well. It will take $HOME by default.
+
+After this script is executed, a directory called _openwhisk_release_ will be created under the home directory of openwhisk
+release tool, if it is not available. The directory _openwhisk_release_ will save the output files, including the source code
+of all the OpenWhisk repositories, packages to be rleased, signature, checksums, etc, when we run any bash script of this
+release tool.
 
 ## Checkout the subversion repository
 
 We need to checkout the subversion repository for OpenWhisk to stage the artifacts with the following command:
+
 ```
-$ ./checkout_svn.sh <WORK_DIR> <SVN_USERNAME> <SVN_PASSWORD>
+$ ./checkout_svn.sh <SVN_USERNAME> <SVN_PASSWORD>
 ```
 
-The <WORK_DIR> should be the same one used to download the source code. If you have already configured your local
-svn command with a pair of username and password, there is no need to provide the values for the arguments <SVN_USERNAME>
-and <SVN_PASSWORD>. With this command, a remote folder named openwhisk-$version will be created in the subversion
-repository if necessary, and checked out to the local folder <WORK_DIR>/openwhisk_release/openwhisk/openwhisk-$full_version.
+If you have configured your local SVN with the username and the password, you can run the above script without the parameters.
+
+After running this command, a remote folder named openwhisk-$version will be created in the subversion
+repository if necessary, and checked out to the local folder openwhisk_release/openwhisk/openwhisk-$full_version.
 The value of $full_version is $version-$pre_release_version, as defined in config.json. This command can also be used to
 sync-up your local folder with the remote subversion folder.

--- a/docs/prepare_release.md
+++ b/docs/prepare_release.md
@@ -19,7 +19,7 @@
 
 # Prepare OpenWhisk projects for a release
 
-  1. Make sure all unit and integration tests are passing in all the projects to be release. Check the [project list](general_spec.md#list-of-openwhisk-repositories-to-be-released).
+  1. Make sure all unit and integration tests are passing in all the projects to be released. Check the [project list](../README.md#project-status).
   2. Make sure the license file LICENSE.txt and the notice file NOTICE.txt exist in each project repository. The license
   file contains the Apache V2.0 license and the notice file includes the dependencies.
   3. Update the release notes. (It is still to be determined where to publish the release notes)

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -23,30 +23,32 @@
 
 This project is only supported under Mac or Ununtu operating system.
 
-## Software packages
-
-The following software packages are required for your operating system.
-
- - git and svn
- - jq
- - gpg or gnupg and expect
-
 ## Download the source code
 
-Open a terminal, go to the directory where you save the source code, and run
+Open a terminal, go to the directory where you save the source code of this release tool, and run
+
 ```
 $ git clone https://github.com/apache/incubator-openwhisk-release.git
 ```
 
+The directory _incubator-openwhisk-release_ becomes the home directory of openwhisk release tool, which will be referred to
+in the following context.
+
 ## Install the dependencies
 
-Normally, Mac or Ubuntu will have some the packages installed by default. Suppose _$OPENWHISK_RELEASE_ is the home directory
-of openwhisk release on your local machine. You can run the script _install_dependencies.sh_ under the folder _tools_
-to install the software packages:
+After running the "git clone" command to download the source code this release repository, you need to run the following
+command to install all the dependencies:
+
 ```
-$ cd $OPENWHISK_RELEASE/tools
+$ cd incubator-openwhisk-release/tools
 $ ./install_dependencies.sh
 ```
 
 For some old versions of Ubuntu, you probably need to run _sudo apt-get update_ before running the script to install
 dependencies.
+
+Your local machine should have the following packages, if the dependencies are installed:
+
+ - svn
+ - jq
+ - gpg or gnupg and expect

--- a/docs/push_stage_url.md
+++ b/docs/push_stage_url.md
@@ -23,9 +23,8 @@ After the artifacts are generated and signed, you can run the following script u
 into the staging directory:
 
 ```
-$ ./upload_artifacts.sh <WORK_DIR>
+$ ./upload_artifacts.sh
 ```
 
-The <WORK_DIR> should be the same one used to download the source code. This script will create a remote directory named
-openwhisk-\<version\>-\<pre_release_version\> under the staging directory, and push all the files available locally under openwhisk-\<version\>-\<pre_release_version\>
+This script will create a remote directory named openwhisk-\<version\>-\<pre_release_version\> under the staging directory, and push all the files available locally under openwhisk-\<version\>-\<pre_release_version\>
 upstream. It will overwrite the old files or directories, if the directory openwhisk-\<version\>-\<pre_release_version\> is available as a svn folder.

--- a/docs/sign_artifacts.md
+++ b/docs/sign_artifacts.md
@@ -47,8 +47,9 @@ The configuration to generate PGP key pair needs to be associated with an identi
 All the artifacts can be signed by running the following script under _tools_:
 
 ```
-$ ./sign_artifacts.sh <WORK_DIR>
+$ ./sign_artifacts.sh <SVN_USERNAME> <SVN_PASSWORD>
 ```
+                      
+If you have configured your local SVN with the username and the password, you can run the above script without the parameters.
 
-The <WORK_DIR> should be the same one used to download the source code. This script generates a file of the MD5 checksum suffixed with .md5,
-a file of the SHA512 checksum suffixed with .sha512, and a signature file suffixed with .asc for each package.
+This script generates a file of the MD5 checksum suffixed with .md5, a file of the SHA512 checksum suffixed with .sha512, and a signature file suffixed with .asc for each package.

--- a/docs/upload_public_key.md
+++ b/docs/upload_public_key.md
@@ -22,7 +22,8 @@
 The public PGP key file is named _KEYS_ available under the [staging directory](https://dist.apache.org/repos/dist/dev/incubator/openwhisk/). If you generate a new key to
 sign the artifacts, you need to update the file of public key in the staging directory for further use to verify the
 artifacts. Checkout the [staging directory](https://dist.apache.org/repos/dist/dev/incubator/openwhisk/) via subversion,
-modify the file KEYS by appending your local public key, and commit it back to the staging directory.
+modify the file KEYS by appending your local public key, and commit it back to the staging directory. Please refer to the
+[svn commands](http://svnbook.red-bean.com/en/1.7/svn.ref.html) to checkout, and commit.
 
 You can export your public PGP key by running the following command:
 
@@ -32,3 +33,7 @@ $ pgp --export <key_id>
 
 The parameter <key_id> can be either the key id or the email address you used to generate the key. For detailed information
 on PGP keys, please visit [how to create and manage PGP keys](https://support.symantec.com/en_US/article.HOWTO41935.html).
+
+## How to commit to the staging directory
+
+Under the home directory of openwhisk release tool, you can find the local SVN directory openwhisk_release/

--- a/tools/checkout_svn.sh
+++ b/tools/checkout_svn.sh
@@ -20,10 +20,8 @@ set -e
 
 echo "Checkout the SVN to the local directory."
 
-WORK_DIR=${1:-"$HOME"}
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-source "$SCRIPTDIR/load_config.sh" $1 $2 $3
+source "$SCRIPTDIR/load_config.sh" $1 $2
 
 if [[ `wget -S --spider $CURRENT_VERSION_URL  2>&1 | grep 'HTTP/1.1 404 Not Found'` ]]; then
     # Create an empty folder named ${REMOTE_PATH} in the remote staging folder

--- a/tools/clean_remote_release_artifacts.sh
+++ b/tools/clean_remote_release_artifacts.sh
@@ -21,11 +21,10 @@ set -e
 echo "Clean the remote artifacts in release directory"
 
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-WORK_DIR=${1:-"$HOME"}
-SVN_USERNAME=$2
-SVN_PASSWORD=$3
+SVN_USERNAME=$1
+SVN_PASSWORD=$2
 
-source "$SCRIPTDIR/load_config.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+source "$SCRIPTDIR/load_config.sh" "$SVN_USERNAME" "$SVN_PASSWORD"
 
 if [[ `wget -S --spider $RELEASE_VERSION_URL  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
     svn delete $RELEASE_VERSION_URL -m "Removing Apache OpenWhisk release ${version}." $CREDENTIALS

--- a/tools/clean_remote_stage_artifacts.sh
+++ b/tools/clean_remote_stage_artifacts.sh
@@ -21,11 +21,10 @@ set -e
 echo "Clean the remote artifacts in staging directory"
 
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-WORK_DIR=${1:-"$HOME"}
-SVN_USERNAME=$2
-SVN_PASSWORD=$3
+SVN_USERNAME=$1
+SVN_PASSWORD=$2
 
-source "$SCRIPTDIR/load_config.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+source "$SCRIPTDIR/load_config.sh" "$SVN_USERNAME" "$SVN_PASSWORD"
 
 if [[ `wget -S --spider $CURRENT_VERSION_URL  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
     svn delete $CURRENT_VERSION_URL -m "Removing Apache OpenWhisk release ${full_version} from staging." $CREDENTIALS

--- a/tools/config.json
+++ b/tools/config.json
@@ -22,7 +22,7 @@
     "openwhisk-runtime-python"
   ],
   "openwhisk": {
-    "hash": "0f0063b",
+    "hash": "1d79fa3",
     "repository": "https://github.com/apache/incubator-openwhisk.git",
     "branch": "master"
   },
@@ -33,7 +33,7 @@
     "binaries": "no"
   },
   "openwhisk_cli": {
-    "hash": "ea1d97c",
+    "hash": "a4ca79a",
     "repository": "https://github.com/apache/incubator-openwhisk-cli.git",
     "branch": "master",
     "binaries": "no"

--- a/tools/download_source_code.sh
+++ b/tools/download_source_code.sh
@@ -18,12 +18,10 @@
 
 set -e
 
-WORK_DIR=${1:-"$HOME"}
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-source "$SCRIPTDIR/load_config.sh" $1
+source "$SCRIPTDIR/load_config.sh"
 
-clone_depth=${2:-"100"}
+clone_depth=${1:-"100"}
 
 function git_clone_repo() {
     PROJECT_NAME=$1

--- a/tools/generate_release_notes.sh
+++ b/tools/generate_release_notes.sh
@@ -18,10 +18,8 @@
 
 echo "Generate release notes and collect change logs of all projects."
 
-WORK_DIR=${1:-"$HOME"}
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-source "$SCRIPTDIR/load_config.sh" $1
+source "$SCRIPTDIR/load_config.sh"
 PARENTDIR="$(dirname "$SCRIPTDIR")"
 
 FILE="$OPENWHISK_SOURCE_DIR/releaseNotes.md"

--- a/tools/load_config.sh
+++ b/tools/load_config.sh
@@ -16,26 +16,30 @@
 # limitations under the License.
 #
 
-WORK_DIR=${1:-"$HOME"}
 DIR="$(cd $(dirname "$0")/ && pwd)"
-SVN_USERNAME=$2
-SVN_PASSWORD=$3
-SCRIPTDIR=${4:-"$DIR"}
+SVN_USERNAME=$1
+SVN_PASSWORD=$2
+SCRIPTDIR=${3:-"$DIR"}
 CREDENTIALS=""
+
+CURRENTDIR="$(cd $(dirname "$0")/ && pwd)"
+PARENTDIR="$(dirname "$CURRENTDIR")"
 
 if [ ! -z "$SVN_USERNAME" ] && [ ! -z "$SVN_PASSWORD" ];then
     CREDENTIALS="--username $SVN_USERNAME --password $SVN_PASSWORD --non-interactive"
 fi
 
-OPENWHISK_RELEASE_DIR="$WORK_DIR/openwhisk_release"
+source "$SCRIPTDIR/util.sh"
+
+CONFIG=$(read_file $SCRIPTDIR/config.json)
+OPENWHISK_RELEASE_DIR="$PARENTDIR/openwhisk_release"
+
 OPENWHISK_SOURCE_DIR="$OPENWHISK_RELEASE_DIR/openwhisk_sources"
+
 OPENWHISK_CLEANED_SOURCE_DIR="$OPENWHISK_RELEASE_DIR/openwhisk_cleaned_sources"
 OPENWHISK_SVN="$OPENWHISK_RELEASE_DIR/openwhisk"
 OPENWHISK_PROJECT_NAME="apache-openwhisk"
 
-source "$SCRIPTDIR/util.sh"
-
-CONFIG=$(read_file $SCRIPTDIR/config.json)
 PUBLISH_STAGE=$(json_by_key "$CONFIG" "publish_stage")
 repos=$(echo $(json_by_key "$CONFIG" "RepoList") | sed 's/[][]//g')
 STAGE_URL=$(json_by_key "$CONFIG" "stage_url")

--- a/tools/move_stage_to_release.sh
+++ b/tools/move_stage_to_release.sh
@@ -21,11 +21,10 @@ set -e
 echo "Move the remote artifacts from staging to release directory."
 
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-WORK_DIR=${1:-"$HOME"}
-SVN_USERNAME=$2
-SVN_PASSWORD=$3
+SVN_USERNAME=$1
+SVN_PASSWORD=$2
 
-source "$SCRIPTDIR/load_config.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+source "$SCRIPTDIR/load_config.sh" "$SVN_USERNAME" "$SVN_PASSWORD"
 
 if [[ `wget -S --spider $RELEASE_VERSION_URL  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
     svn delete $RELEASE_VERSION_URL -m "Removing Apache OpenWhisk release ${full_version}." $CREDENTIALS

--- a/tools/sign_artifacts.sh
+++ b/tools/sign_artifacts.sh
@@ -20,11 +20,10 @@ set -e
 
 echo "Sign the artifacts with PGP."
 
-WORK_DIR=${1:-"$HOME"}
-passphrase=${2:-"openwhisk"}
+passphrase=${1:-"openwhisk"}
 
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-source "$SCRIPTDIR/load_config.sh" $1
+source "$SCRIPTDIR/load_config.sh"
 
 # Sign all the artifacts with the PGP key.
 export GPG_TTY=$(tty)
@@ -36,8 +35,8 @@ fi
 
 cd $CURRENT_VERSION_DIR
 echo "Sign the artifacts with the private key."
-for artifact in *.tar.gz *.zip; do
-    if [ "${artifact}" != "*.tar.gz" ] && [ "${artifact}" != "*.zip"  ] ; then
+for artifact in *.tar.gz *.zip *.tgz; do
+    if [ "${artifact}" != "*.tar.gz" ] && [ "${artifact}" != "*.zip" ] && [ "${artifact}" != "*.tgz" ] ; then
         gpg --print-md MD5 ${artifact} > ${artifact}.md5
         gpg --print-md SHA512 ${artifact} > ${artifact}.sha512
 
@@ -50,4 +49,4 @@ for artifact in *.tar.gz *.zip; do
     fi
 done
 
-#ls
+ls

--- a/tools/travis/package_project.sh
+++ b/tools/travis/package_project.sh
@@ -18,37 +18,34 @@
 
 set -e
 
-WORK_DIR=${1:-"$(dirname "$TRAVIS_BUILD_DIR")"}
-OPENWHISK_SOURCE_DIR="$WORK_DIR/openwhisk_sources"
-
 CURRENTDIR="$(cd $(dirname "$0")/ && pwd)"
 PARENTDIR="$(dirname "$CURRENTDIR")"
 
-SVN_USERNAME=$2
-SVN_PASSWORD=$3
+SVN_USERNAME=$1
+SVN_PASSWORD=$2
 
 "$PARENTDIR/install_dependencies.sh"
 
 if [ ! -z "$TRAVIS_TAG" ] ; then
     # The git tag is named after the version to be released.
     release_version=$TRAVIS_TAG
-    source "$PARENTDIR/load_config.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD" "$PARENTDIR" "$release_version"
-    "$PARENTDIR/move_stage_to_release.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+    source "$PARENTDIR/load_config.sh" "$SVN_USERNAME" "$SVN_PASSWORD" "$PARENTDIR" "$release_version"
+    "$PARENTDIR/move_stage_to_release.sh" "$SVN_USERNAME" "$SVN_PASSWORD"
 else
-    source "$PARENTDIR/load_config.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD" "$PARENTDIR"
-    "$PARENTDIR/download_source_code.sh" "$WORK_DIR"
+    source "$PARENTDIR/load_config.sh" "$SVN_USERNAME" "$SVN_PASSWORD" "$PARENTDIR"
+    "$PARENTDIR/download_source_code.sh"
     if [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ "$PUBLISH_STAGE" == "true" ] ; then
-        "$PARENTDIR/checkout_svn.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+        "$PARENTDIR/checkout_svn.sh" "$SVN_USERNAME" "$SVN_PASSWORD"
     fi
 
-    "$PARENTDIR/package_source_code.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
-    "$PARENTDIR/package_binaries.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+    "$PARENTDIR/package_source_code.sh"
+    "$PARENTDIR/package_binaries.sh"
 
     if [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ "$PUBLISH_STAGE" == "true" ] ; then
         "$CURRENTDIR/import_pgp_key.sh"
-        "$PARENTDIR/sign_artifacts.sh" "$WORK_DIR"
-        "$PARENTDIR/upload_artifacts.sh" "$WORK_DIR" "$SVN_USERNAME" "$SVN_PASSWORD"
+        "$PARENTDIR/sign_artifacts.sh"
+        "$PARENTDIR/upload_artifacts.sh" "$SVN_USERNAME" "$SVN_PASSWORD"
     fi
 
-    "$PARENTDIR/verify_source_code.sh" "$WORK_DIR"
+    "$PARENTDIR/verify_source_code.sh"
 fi

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -20,27 +20,29 @@ set -e
 
 echo "hello openwhisk release"
 
-# Define the parent directory of TRAVIS_BUILD_DIR(the directory of the current repository) as HOMEDIR
-WORK_DIR=${1:-"$(dirname "$TRAVIS_BUILD_DIR")"}
-OPENWHISKDIR="$WORK_DIR/openwhisk_sources"
-SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-PARENTDIR="$(dirname "$SCRIPTDIR")"
+SVN_USERNAME=$1
+SVN_PASSWORD=$2
+
+CURRENTDIR="$(cd $(dirname "$0")/ && pwd)"
+PARENTDIR="$(dirname "$CURRENTDIR")"
+
+source "$PARENTDIR/load_config.sh" "$SVN_USERNAME" "$SVN_PASSWORD" "$PARENTDIR"
 
 SUFFIX="$TRAVIS_BUILD_NUMBER"
 PR_NUM="$TRAVIS_PULL_REQUEST"
 PREFIX="build_testing"
 
-export OPENWHISK_HOME="$OPENWHISKDIR/incubator-openwhisk";
+export OPENWHISK_HOME="$OPENWHISK_SOURCE_DIR/incubator-openwhisk";
 
-mkdir -p $OPENWHISKDIR
-cd $OPENWHISKDIR
+mkdir -p $OPENWHISK_SOURCE_DIR
+cd $OPENWHISK_SOURCE_DIR
 
 echo "list images in setup before build"
 docker images
 
-"$PARENTDIR/download_source_code.sh" $WORK_DIR
+"$PARENTDIR/download_source_code.sh"
 
-cd $OPENWHISKDIR/incubator-openwhisk
+cd $OPENWHISK_SOURCE_DIR/incubator-openwhisk
 ./tools/travis/setup.sh
 TERM=dumb ./gradlew core:controller:distDocker core:invoker:distDocker -PdockerImagePrefix=$PREFIX
 
@@ -55,9 +57,9 @@ $ANSIBLE_CMD wipe.yml
 $ANSIBLE_CMD openwhisk.yml
 
 # Build the binaries for CLI
-cd $OPENWHISKDIR/incubator-openwhisk-cli
+cd $OPENWHISK_SOURCE_DIR/incubator-openwhisk-cli
 #./gradlew buildBinaries -PcrossCompileCLI=true
 
 # Build the binaries for wskdeploy
-cd $OPENWHISKDIR/incubator-openwhisk-wskdeploy
+cd $OPENWHISK_SOURCE_DIR/incubator-openwhisk-wskdeploy
 #./gradlew distDocker -PcrossCompileWSKDEPLOY=true

--- a/tools/travis/verify_source_code.sh
+++ b/tools/travis/verify_source_code.sh
@@ -18,16 +18,13 @@
 
 set -e
 
-WORK_DIR=${1:-"$(dirname "$TRAVIS_BUILD_DIR")"}
-OPENWHISK_SOURCE_DIR="$WORK_DIR/openwhisk_sources"
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 PARENTDIR="$(dirname "$SCRIPTDIR")"
 
 echo $PARENTDIR
 "$PARENTDIR/install_dependencies.sh"
-"$PARENTDIR/download_source_code.sh" $WORK_DIR
-"$PARENTDIR/verify_source_code.sh" $WORK_DIR
+"$PARENTDIR/download_source_code.sh"
+"$PARENTDIR/verify_source_code.sh"
 
 # TODO: verify the source code headers
 echo "TODO: verify the source code headers"

--- a/tools/upload_artifacts.sh
+++ b/tools/upload_artifacts.sh
@@ -20,10 +20,8 @@ set -e
 
 echo "Upload the artifacts."
 
-WORK_DIR=${1:-"$HOME"}
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-source "$SCRIPTDIR/load_config.sh" $1 $2 $3
+source "$SCRIPTDIR/load_config.sh" $1 $2
 
 cd $OPENWHISK_SVN/$REMOTE_PATH
 

--- a/tools/verify_source_code.sh
+++ b/tools/verify_source_code.sh
@@ -18,10 +18,8 @@
 
 echo "Generate the report regarding the source code headers."
 
-WORK_DIR=${1:-"$HOME"}
-
 SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-source "$SCRIPTDIR/load_config.sh" $1
+source "$SCRIPTDIR/load_config.sh"
 PARENTDIR="$(dirname "$SCRIPTDIR")"
 
 # run Apache rat to check headers


### PR DESCRIPTION
This PR removes the parameter "WORK_DIR" for each script, in order to reduce the complexity. The openwhisk release folder will be created under the home directory of the incubator-openwhisk-release repository saved on the local machine. 