### PR TITLE
Fix the issue in Travis build of master branch

### DIFF
--- a/tools/sign_artifacts.sh
+++ b/tools/sign_artifacts.sh
@@ -36,16 +36,18 @@ fi
 
 cd $CURRENT_VERSION_DIR
 echo "Sign the artifacts with the private key."
-for artifact in *.tar.gz *.zip *.tgz; do
-    gpg --print-md MD5 ${artifact} > ${artifact}.md5
-    gpg --print-md SHA512 ${artifact} > ${artifact}.sha512
+for artifact in *.tar.gz *.zip; do
+    if [ "${artifact}" != "*.tar.gz" ] && [ "${artifact}" != "*.zip"  ] ; then
+        gpg --print-md MD5 ${artifact} > ${artifact}.md5
+        gpg --print-md SHA512 ${artifact} > ${artifact}.sha512
 
-    if [ $sysOS == "Darwin" ];then
-        # The option --passphrase-fd does not work on Mac.
-        `gpg --yes --armor --output ${artifact}.asc --detach-sig ${artifact}`
-    elif [ $sysOS == "Linux" ];then
-        `echo $passphrase | gpg --passphrase-fd 0 --yes --armor --output ${artifact}.asc --detach-sig ${artifact}`
+        if [ $sysOS == "Darwin" ];then
+            # The option --passphrase-fd does not work on Mac.
+            `gpg --yes --armor --output ${artifact}.asc --detach-sig ${artifact}`
+        elif [ $sysOS == "Linux" ];then
+            `echo $passphrase | gpg --passphrase-fd 0 --yes --armor --output ${artifact}.asc --detach-sig ${artifact}`
+        fi
     fi
 done
 
-ls
+#ls


### PR DESCRIPTION
In bash scripts, when searching for files with certain suffixes under
a directory, we need to exclude the ones with *, since they are the
expression not the files.