### PR TITLE
Add script to package the documents

### DIFF
--- a/docs/package_artifacts.md
+++ b/docs/package_artifacts.md
@@ -41,5 +41,13 @@ After downloading the source code, we can run the following script under _tools_
 ```
 $ ./package_source_code.sh
 ```
-This script will create a source code package file of source code suffixed with tar.gz for each project, under <local_release_dir>/openwhisk_sources/openwhisk/openwhisk-\<version\>.
+This script will create a source code package file of source code suffixed with tar.gz for each project, under <local_release_dir>/openwhisk_sources/openwhisk/apache-openwhisk-\<version\>.
 The key version is defined in _config.json_.
+
+## Adding or updating the documents
+
+We can run the following script under _tools_ to add or update the documents for the current release:
+```
+$ ./package_doc.sh
+```
+This script will copy all the files under releases/<current version> into the designated directory, <local_release_dir>/openwhisk_sources/openwhisk/apache-openwhisk-\<version\>/doc/.

--- a/tools/config.json
+++ b/tools/config.json
@@ -1,5 +1,6 @@
 {
-  "publish_stage": "true",
+  "publish_stage": "false",
+  "update_doc": "true",
   "stage_url": "https://dist.apache.org/repos/dist/dev/incubator/openwhisk",
   "release_url": "https://dist.apache.org/repos/dist/release/incubator/openwhisk",
   "versioning": {

--- a/tools/load_config.sh
+++ b/tools/load_config.sh
@@ -41,6 +41,7 @@ OPENWHISK_SVN="$OPENWHISK_RELEASE_DIR/openwhisk"
 OPENWHISK_PROJECT_NAME="apache-openwhisk"
 
 PUBLISH_STAGE=$(json_by_key "$CONFIG" "publish_stage")
+UPDATE_DOC=$(json_by_key "$CONFIG" "update_doc")
 repos=$(echo $(json_by_key "$CONFIG" "RepoList") | sed 's/[][]//g')
 STAGE_URL=$(json_by_key "$CONFIG" "stage_url")
 RELEASE_URL=$(json_by_key "$CONFIG" "release_url")

--- a/tools/package_doc.sh
+++ b/tools/package_doc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+echo "Package the documents."
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+source "$SCRIPTDIR/load_config.sh" $1 $2 $3
+
+mkdir -p $CURRENT_VERSION_DIR
+
+# Copy the documents for the current release into the $CURRENT_VERSION_DIR directory
+PARENTDIR="$(dirname "$SCRIPTDIR")"
+mkdir -p ${CURRENT_VERSION_DIR}/doc
+cp $PARENTDIR/releases/$version/* ${CURRENT_VERSION_DIR}/doc/

--- a/tools/package_source_code.sh
+++ b/tools/package_source_code.sh
@@ -42,8 +42,3 @@ do
     mv $project_name $project_name-$version
     tar czf ${CURRENT_VERSION_DIR}/${repo_name}-${version}-sources.tar.gz $project_name-$version
 done
-
-# Copy the documents for the current release into the $CURRENT_VERSION_DIR directory
-PARENTDIR="$(dirname "$SCRIPTDIR")"
-mkdir -p ${CURRENT_VERSION_DIR}/doc
-cp $PARENTDIR/releases/$version/* ${CURRENT_VERSION_DIR}/doc/


### PR DESCRIPTION
This PR adds another flag called UPDATE_DOC to determine if the commit
is going to change the documents or not.

Besides, it re-arranged the logic when a PR is merged into master.
It separated the conditions based on the TRAVIS_EVENT_TYPE, so that
pull requests and pushes can be more trackable.