### PR TITLE
Output the script's SHA1 as a version ID

### DIFF
--- a/tools/rcverify.sh
+++ b/tools/rcverify.sh
@@ -59,6 +59,8 @@ The Apache Software Foundation (http://www.apache.org/).
 END
 )
 
+echo "$(basename $0) (script SHA1: $(gpg --print-md SHA1 $0 | cut -d' ' -f2-))"
+
 DIR=$(mktemp -d)
 
 echo working in the following directory:


### PR DESCRIPTION
This outputs the script's name and SHA1 as a version ID at startup, like

    rcverify.sh (script SHA1: 03C3 415D 60B4 F15B 366A  C414 ADE9 FE89 295E 7671)

so that when people include the rcverify.sh output when voting in releases we know which version they ran. I think SHA1 is good enough for that and it's a reasonably small digest.
