### PR TITLE
Emit download URL.

### DIFF
--- a/tools/rcverify.sh
+++ b/tools/rcverify.sh
@@ -67,14 +67,17 @@ echo working in the following directory:
 echo "$(tput setaf 6)$DIR$(tput sgr0)"
 
 if [ $DL -ne 0 ]; then
+  SRC=$DIST/apache-openwhisk-$V-$RC
+  echo fetching tarball and signatures from $SRC
+
   echo fetching $TGZ
-  curl $DIST/apache-openwhisk-$V-$RC/$TGZ -s -o "$DIR/$TGZ"
+  curl $SRC/$TGZ -s -o "$DIR/$TGZ"
 
   echo fetching $TGZ.asc
-  curl $DIST/apache-openwhisk-$V-$RC/$TGZ.asc -s -o "$DIR/$TGZ.asc"
+  curl $SRC/$TGZ.asc -s -o "$DIR/$TGZ.asc"
 
   echo fetching $TGZ.sha512
-  curl $DIST/apache-openwhisk-$V-$RC/$TGZ.sha512 -s -o "$DIR/$TGZ.sha512"
+  curl $SRC/$TGZ.sha512 -s -o "$DIR/$TGZ.sha512"
 fi
 
 if [ $IMPORT -ne 0 ]; then


### PR DESCRIPTION
```
> rcverify.sh openwhisk-runtime-go 'OpenWhisk Runtime Go' 1.13.0-incubating rc2
rcverify.sh (script SHA1: EAFD 9EFB 2FFE 32EF 8AAD  31B3 4478 779B 4A26 F1A5)
working in the following directory:
/var/folders/q9/s3th42s53d34ftd5wvcypybr0000gn/T/tmp.eJ9sTFx3
fetching tarball and signatures from https://dist.apache.org/repos/dist/dev/incubator/openwhisk/apache-openwhisk-1.13.0-incubating-rc2
fetching openwhisk-runtime-go-1.13.0-incubating-sources.tar.gz
fetching openwhisk-runtime-go-1.13.0-incubating-sources.tar.gz.asc
fetching openwhisk-runtime-go-1.13.0-incubating-sources.tar.gz.sha512
```