### PR TITLE
exclude credentials.json.enc in package_source_code.sh

### DIFF
--- a/tools/package_source_code.sh
+++ b/tools/package_source_code.sh
@@ -30,7 +30,7 @@ mkdir -p $CURRENT_VERSION_DIR
 # Remove bin and build folders
 mkdir -p $OPENWHISK_CLEANED_SOURCE_DIR
 rm -rf $OPENWHISK_CLEANED_SOURCE_DIR/*
-rsync -rtp --exclude gradle/wrapper/gradle-\*.jar --exclude .bin --exclude .jshintrc --exclude .pydevproject --exclude .rat-excludes --exclude .git\* --exclude .travis.yml --exclude build --exclude specification/archive --exclude specification/diagrams $OPENWHISK_SOURCE_DIR/. $OPENWHISK_CLEANED_SOURCE_DIR
+rsync -rtp --exclude gradle/wrapper/gradle-\*.jar --exclude .bin --exclude .jshintrc --exclude .pydevproject --exclude .rat-excludes --exclude .git\* --exclude .travis.yml --exclude credentials.json.enc --exclude build --exclude specification/archive --exclude specification/diagrams $OPENWHISK_SOURCE_DIR/. $OPENWHISK_CLEANED_SOURCE_DIR
 
 for repo in $(echo $repos | sed "s/,/ /g")
 do


### PR DESCRIPTION
Some repos have encrypted credentials used as part of TravisCI
testing in a top-level file with this name.  Since we exclude
.travis.yml from the release, also exclude these credentials.